### PR TITLE
get schema only once per file on merge, reduce duplicate data in mem

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -61,3 +61,9 @@ tasks:
       - sqlc generate
       - rm schema.sql*
       - echo done
+
+  docker:
+    cmds:
+      - docker build . -t us-east1-docker.pkg.dev/twitchdata-370813/twitch-scraper/icedb:latest --ssh default
+      - gcloud auth configure-docker us-east1-docker.pkg.dev --account=$GCP_ACCOUNT
+      - docker push us-east1-docker.pkg.dev/twitchdata-370813/twitch-scraper/icedb:latest

--- a/http_server/insert.http
+++ b/http_server/insert.http
@@ -17,7 +17,7 @@ POST http://localhost:8080/insert
 Content-Type: application/json
 
 {
-  "Namespace": "testnse",
+  "Namespace": "testns",
   "Rows": [{"yyy":"eee"}, {"bbb":[["zzz"]]}, {"c":  12}, {"d":  [1.3]}],
   "Partitioner": [{
     "Func": "toDay",

--- a/migrations/20221229124747-files.sql
+++ b/migrations/20221229124747-files.sql
@@ -10,6 +10,8 @@ CREATE TABLE files (
     rows INT8 NOT NULL,
     columns TEXT[] NOT NULL,
 
+    json_schema JSONB NOT NULL,
+
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 

--- a/parquet_accumulator/parquet_accumulator_test.go
+++ b/parquet_accumulator/parquet_accumulator_test.go
@@ -41,7 +41,7 @@ func TestGetSchemaString(t *testing.T) {
 	}
 	if schemaString != `{"Tag":"name=parquet_go_root, repetitiontype=REQUIRED","Fields":[{"Tag":"type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN, name=colA, repetitiontype=OPTIONAL"},{"Tag":"type=DOUBLE, name=colB, repetitiontype=OPTIONAL"},{"Tag":"type=LIST, name=colC, repetitiontype=OPTIONAL","Fields":[{"Tag":"type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN, name=Element, repetitiontype=OPTIONAL"}]}]}` {
 		t.Log(schemaString)
-		t.Fatal("got incorrect schema string")
+		t.Fatal("got incorrect Schema string")
 	}
 
 }

--- a/pq_byte_reader/pq_byte_reader.go
+++ b/pq_byte_reader/pq_byte_reader.go
@@ -1,0 +1,113 @@
+package pq_byte_reader
+
+import (
+	"errors"
+	"io"
+
+	"github.com/xitongsys/parquet-go/source"
+)
+
+// BufferFile allows reading parquet messages from a memory buffer.
+type BufferFile struct {
+	buff []byte
+	loc  int
+}
+
+// DefaultCapacity is the size in bytes of a new BufferFile's backing buffer
+const DefaultCapacity = 512
+
+// NewBufferFile creates new in memory parquet buffer.
+func NewBufferFile() *BufferFile {
+	return NewBufferFileCapacity(DefaultCapacity)
+}
+
+// NewBufferFileFromBytes creates new in memory parquet buffer from the given bytes.
+func NewBufferFileFromBytes(s []byte) *BufferFile {
+	return &BufferFile{buff: s}
+}
+
+// NewBufferFileCapacity starts the returned BufferFile with the given capacity
+func NewBufferFileCapacity(cap int) *BufferFile {
+	return &BufferFile{buff: make([]byte, 0, cap)}
+}
+
+func (bf BufferFile) Create(string) (source.ParquetFile, error) {
+	return NewBufferFile(), nil
+}
+
+func (bf BufferFile) Open(string) (source.ParquetFile, error) {
+	return NewBufferFileFromBytes(bf.buff), nil
+}
+
+// Seek seeks in the underlying memory buffer.
+func (bf *BufferFile) Seek(offset int64, whence int) (int64, error) {
+	newLoc := bf.loc
+	switch whence {
+	case io.SeekStart:
+		newLoc = int(offset)
+	case io.SeekCurrent:
+		newLoc += int(offset)
+	case io.SeekEnd:
+		newLoc = len(bf.buff) + int(offset)
+	}
+
+	if newLoc < 0 {
+		return int64(bf.loc), errors.New("unable to seek to a location <0")
+	}
+
+	if newLoc > len(bf.buff) {
+		newLoc = len(bf.buff)
+	}
+
+	bf.loc = newLoc
+
+	return int64(bf.loc), nil
+}
+
+// Read reads data form BufferFile into p.
+func (bf *BufferFile) Read(p []byte) (n int, err error) {
+	n = copy(p, bf.buff[bf.loc:len(bf.buff)])
+	bf.loc += n
+
+	if bf.loc == len(bf.buff) {
+		return n, io.EOF
+	}
+
+	return n, nil
+}
+
+// Write writes data from p into BufferFile.
+func (bf *BufferFile) Write(p []byte) (n int, err error) {
+	// Do we have space?
+	if available := cap(bf.buff) - bf.loc; available < len(p) {
+		// How much should we expand by?
+		addCap := cap(bf.buff)
+		if addCap < len(p) {
+			addCap = len(p)
+		}
+
+		newBuff := make([]byte, len(bf.buff), cap(bf.buff)+addCap)
+
+		copy(newBuff, bf.buff)
+
+		bf.buff = newBuff
+	}
+
+	// Write
+	n = copy(bf.buff[bf.loc:cap(bf.buff)], p)
+	bf.loc += n
+	if len(bf.buff) < bf.loc {
+		bf.buff = bf.buff[:bf.loc]
+	}
+
+	return n, nil
+}
+
+// Close is a no-op for a memory buffer.
+func (bf BufferFile) Close() error {
+	return nil
+}
+
+func (bf BufferFile) Bytes() []byte {
+	return bf.buff
+}

--- a/queries/files.sql
+++ b/queries/files.sql
@@ -13,7 +13,8 @@ INSERT INTO files (
     rows,
     columns,
     partition,
-    name
+    name,
+    json_schema
 ) VALUES (
     @namespace,
     @enabled,
@@ -21,7 +22,8 @@ INSERT INTO files (
     @rows,
     @columns,
     @partition,
-    @name
+    @name,
+    @json_schema
 )
 ;
 

--- a/query/models.go
+++ b/query/models.go
@@ -6,6 +6,8 @@ package query
 
 import (
 	"time"
+
+	"github.com/jackc/pgtype"
 )
 
 type Column struct {
@@ -16,13 +18,14 @@ type Column struct {
 }
 
 type File struct {
-	Enabled   bool
-	Namespace string
-	Partition string
-	Name      string
-	Bytes     int64
-	Rows      int64
-	Columns   []string
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	Enabled    bool
+	Namespace  string
+	Partition  string
+	Name       string
+	Bytes      int64
+	Rows       int64
+	Columns    []string
+	JsonSchema pgtype.JSONB
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
 }


### PR DESCRIPTION
fix logging, removes extra byte copy to save mem

Before optimization:
```
{
    "FilesMerged": 4,
    "PartitionsMerged": null,
    "PostMergeBytes": 10046542,
    "RowsMerged": 28620,
    "TimeMS": 3075
}
```

After optimization:
```
{
    "FilesMerged": 4,
    "PartitionsMerged": null,
    "PostMergeBytes": 11216829,
    "RowsMerged": 31320,
    "TimeMS": 2917
}
```